### PR TITLE
fix: Ignore NRF URI containing a specific IP on registration

### DIFF
--- a/factory/config.example.yaml
+++ b/factory/config.example.yaml
@@ -1,0 +1,18 @@
+info:
+  version: 1.0.0
+  description: UDR initial local configuration (https://github.com/free5gc/free5gc/blob/main/config/udrcfg.yaml)
+
+configuration:
+  sbi: # Service-based interface information
+    scheme: https
+    registerIPv4: 127.0.0.4
+    bindingIPv4: 0.0.0.0
+    port: 8000
+  plmnSupportList:
+    - plmnId:
+        mcc: "208"
+        mnc: "93"
+      snssaiList:
+        - sst: 1
+          sd: "010203"
+

--- a/factory/config.example.yaml
+++ b/factory/config.example.yaml
@@ -7,7 +7,7 @@ info:
   description: UDR initial local configuration
 
 configuration:
-  sbi: # Service-based interface information
+  sbi: # Service Based Interface
     scheme: https
     registerIPv4: 127.0.0.4
     bindingIPv4: 0.0.0.0

--- a/factory/config.example.yaml
+++ b/factory/config.example.yaml
@@ -1,6 +1,10 @@
+## SPDX-FileCopyrightText: 2023 Open Networking Foundation <info@opennetworking.org>
+##
+## SPDX-License-Identifier: Apache-2.0
+##
 info:
   version: 1.0.0
-  description: UDR initial local configuration (https://github.com/free5gc/free5gc/blob/main/config/udrcfg.yaml)
+  description: UDR initial local configuration
 
 configuration:
   sbi: # Service-based interface information

--- a/factory/config.go
+++ b/factory/config.go
@@ -11,10 +11,10 @@
 package factory
 
 import (
+	protos "github.com/omec-project/config5g/proto/sdcoreConfig"
 	"github.com/omec-project/logger_util"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/udr/logger"
-	protos "github.com/omec-project/config5g/proto/sdcoreConfig"
 )
 
 const (

--- a/service/init.go
+++ b/service/init.go
@@ -307,7 +307,7 @@ func (udr *UDR) configUpdateDb() {
 		if err == nil {
 			initLog.Infof("added entry to sm policy table success")
 		} else {
-			initLog.Errorln("entry add failed ", err)
+			initLog.Errorf("entry add failed %+v", err)
 		}
 	}
 }
@@ -386,15 +386,13 @@ func (udr *UDR) registerNF() {
 		initLog.Infof("Minimum configuration from config pod available %v", msg)
 		self := udr_context.UDR_Self()
 		profile := consumer.BuildNFInstance(self)
-		var newNrfUri string
 		var err error
 		var prof models.NfProfile
 		// send registration with updated PLMN Ids.
-		prof, newNrfUri, self.NfId, err = consumer.SendRegisterNFInstance(self.NrfUri, profile.NfInstanceId, profile)
+		prof, _, self.NfId, err = consumer.SendRegisterNFInstance(self.NrfUri, profile.NfInstanceId, profile)
 		if err == nil {
 			udr.StartKeepAliveTimer(prof)
-			logger.CfgLog.Infof("Sent Register NF Instance with updated profile")
-			self.NrfUri = newNrfUri
+			logger.CfgLog.Infoln("Sent Register NF Instance with updated profile")
 		} else {
 			initLog.Errorf("Send Register NFInstance Error[%s]", err.Error())
 		}

--- a/service/init_test.go
+++ b/service/init_test.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2023 Open Networking Foundation <info@opennetworking.org>
+//
+
+package service
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/omec-project/udr/context"
+	"github.com/omec-project/udr/factory"
+)
+
+func Test_nrf_url_is_not_overwritten_when_registering(t *testing.T) {
+	svr := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "banana")
+	}))
+	svr.EnableHTTP2 = true
+	svr.StartTLS()
+	defer svr.Close()
+	if err := factory.InitConfigFactory("../factory/config.example.yaml"); err != nil {
+		t.Fatalf("Could not read example configuration file")
+	}
+	self := context.UDR_Self()
+	self.NrfUri = svr.URL
+	self.RegisterIPv4 = "127.0.0.2"
+	var udr *UDR
+	go udr.registerNF()
+	factory.ConfigPodTrigger <- true
+
+	time.Sleep(1 * time.Second)
+	if self.NrfUri != svr.URL {
+		t.Errorf("Expected NRF URL to stay %v, but was %v", svr.URL, self.NrfUri)
+	}
+}


### PR DESCRIPTION
This ignores the NRF URI received from the NRF on registration, as the NRF will return its IP, which is subject to change. This is similar to what is done on the AMF.