### PR TITLE
chore: Enable all analyzers in ci govet

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -169,13 +169,10 @@ linters-settings:
           - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
           - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
           - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
-    # enable or disable analyzers by name
-    enable:
-      - atomicalign
-    enable-all: false
+    # enable all analyzers
+    enable-all: true
     disable:
-      - shadow
-    disable-all: false
+      - fieldalignment
   depguard:
     list-type: blacklist
     include-go-root: false


### PR DESCRIPTION
Enable all analyzers and only disable failing check `fieldalignment`