### PR TITLE
Enable fieldalignment go vet check

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -171,8 +171,6 @@ linters-settings:
           - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
     # enable all analyzers
     enable-all: true
-    disable:
-      - fieldalignment
   depguard:
     list-type: blacklist
     include-go-root: false

--- a/context/context.go
+++ b/context/context.go
@@ -36,19 +36,19 @@ type UDRContext struct {
 	Name                                    string
 	UriScheme                               models.UriScheme
 	BindingIPv4                             string
-	SBIPort                                 int
 	RegisterIPv4                            string // IP register to NRF
 	HttpIPv6Address                         string
 	NfId                                    string
 	NrfUri                                  string
+	SubscriptionDataSubscriptions           map[subsId]*models.SubscriptionDataSubscriptions
+	PolicyDataSubscriptions                 map[subsId]*models.PolicyDataSubscription
+	UESubsCollection                        sync.Map // map[ueId]*UESubsData
+	UEGroupCollection                       sync.Map // map[ueGroupId]*UEGroupSubsData
+	SBIPort                                 int
 	EeSubscriptionIDGenerator               int
 	SdmSubscriptionIDGenerator              int
 	PolicyDataSubscriptionIDGenerator       int
-	UESubsCollection                        sync.Map // map[ueId]*UESubsData
-	UEGroupCollection                       sync.Map // map[ueGroupId]*UEGroupSubsData
 	SubscriptionDataSubscriptionIDGenerator int
-	SubscriptionDataSubscriptions           map[subsId]*models.SubscriptionDataSubscriptions
-	PolicyDataSubscriptions                 map[subsId]*models.PolicyDataSubscription
 	appDataInfluDataSubscriptionIdGenerator uint64
 	mtx                                     sync.RWMutex
 }

--- a/factory/config.go
+++ b/factory/config.go
@@ -51,12 +51,12 @@ type PlmnSupportItem struct {
 }
 
 type Sbi struct {
+	Tls          *Tls   `yaml:"tls,omitempty"`
 	Scheme       string `yaml:"scheme"`
 	RegisterIPv4 string `yaml:"registerIPv4,omitempty"` // IP that is registered at NRF.
 	// IPv6Addr string `yaml:"ipv6Addr,omitempty"`
 	BindingIPv4 string `yaml:"bindingIPv4,omitempty"` // IP used to run the server in the node.
 	Port        int    `yaml:"port"`
-	Tls         *Tls   `yaml:"tls,omitempty"`
 }
 
 type Tls struct {

--- a/factory/factory.go
+++ b/factory/factory.go
@@ -29,9 +29,9 @@ type UpdateDb struct {
 }
 
 type SmPolicyUpdateEntry struct {
+	Snssai *protos.NSSAI
 	Imsi   string
 	Dnn    string
-	Snssai *protos.NSSAI
 }
 
 var initLog *logrus.Entry


### PR DESCRIPTION
Enable fieldalignment go vet check in CI
fieldalignment defines an Analyzer that detects structs that would use less memory if their fields were sorted.