### PR TITLE
feat: Store authentication keys in a separate database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ cscope.*
 *.log
 *.pcap
 vendor*
+
+# coverage
+.coverage

--- a/Makefile
+++ b/Makefile
@@ -81,3 +81,17 @@ docker-push:
 	for target in $(DOCKER_TARGETS); do \
 		docker push ${DOCKER_REGISTRY}${DOCKER_REPOSITORY}5gc-$$target:${DOCKER_TAG}; \
 	done
+
+.coverage:
+	rm -rf $(CURDIR)/.coverage
+	mkdir -p $(CURDIR)/.coverage
+
+test: .coverage
+	docker run --rm -v $(CURDIR):/udr -w /udr golang:latest \
+		go test \
+			-failfast \
+			-coverprofile=.coverage/coverage-unit.txt \
+			-covermode=atomic \
+			-v \
+			./ ./...
+

--- a/factory/config.example.yaml
+++ b/factory/config.example.yaml
@@ -12,6 +12,11 @@ configuration:
     registerIPv4: 127.0.0.4
     bindingIPv4: 0.0.0.0
     port: 8000
+  mongodb:
+    name: free5gc
+    url: http://dummy
+    authKeysDbName: authentication
+    authUrl: http://dummy
   plmnSupportList:
     - plmnId:
         mcc: "208"

--- a/factory/config.go
+++ b/factory/config.go
@@ -65,8 +65,10 @@ type Tls struct {
 }
 
 type Mongodb struct {
-	Name string `yaml:"name"`
-	Url  string `yaml:"url"`
+	Name           string `yaml:"name,omitempty"`
+	Url            string `yaml:"url,omitempty"`
+	AuthKeysDbName string `yaml:"authKeysDbName"`
+	AuthUrl        string `yaml:"authUrl"`
 }
 
 var ConfigPodTrigger chan bool

--- a/factory/factory.go
+++ b/factory/factory.go
@@ -50,6 +50,13 @@ func InitConfigFactory(f string) error {
 		if yamlErr := yaml.Unmarshal(content, &UdrConfig); yamlErr != nil {
 			return yamlErr
 		}
+		if UdrConfig.Configuration.Mongodb.AuthUrl == "" {
+			authUrl := UdrConfig.Configuration.Mongodb.Url
+			UdrConfig.Configuration.Mongodb.AuthUrl = authUrl
+		}
+		if UdrConfig.Configuration.Mongodb.AuthKeysDbName == "" {
+			UdrConfig.Configuration.Mongodb.AuthKeysDbName = "authentication"
+		}
 		roc := os.Getenv("MANAGED_BY_CONFIG_POD")
 		if roc == "true" {
 			initLog.Infoln("MANAGED_BY_CONFIG_POD is true")

--- a/producer/data_repository.go
+++ b/producer/data_repository.go
@@ -377,7 +377,7 @@ func HandleModifyAuthentication(request *httpwrapper.Request) *httpwrapper.Respo
 
 func ModifyAuthenticationProcedure(collName string, ueId string, patchItem []models.PatchItem) *models.ProblemDetails {
 	filter := bson.M{"ueId": ueId}
-	origValue, errGetOne := CommonDBClient.RestfulAPIGetOne(collName, filter)
+	origValue, errGetOne := AuthDBClient.RestfulAPIGetOne(collName, filter)
 	if errGetOne != nil {
 		logger.DataRepoLog.Warnln(errGetOne)
 	}
@@ -386,10 +386,10 @@ func ModifyAuthenticationProcedure(collName string, ueId string, patchItem []mod
 	if err != nil {
 		logger.DataRepoLog.Error(err)
 	}
-	failure := CommonDBClient.RestfulAPIJSONPatch(collName, filter, patchJSON)
+	failure := AuthDBClient.RestfulAPIJSONPatch(collName, filter, patchJSON)
 
 	if failure == nil {
-		newValue, errGetOneNew := CommonDBClient.RestfulAPIGetOne(collName, filter)
+		newValue, errGetOneNew := AuthDBClient.RestfulAPIGetOne(collName, filter)
 		if errGetOneNew != nil {
 			logger.DataRepoLog.Warnln(errGetOneNew)
 		}
@@ -421,7 +421,7 @@ func HandleQueryAuthSubsData(request *httpwrapper.Request) *httpwrapper.Response
 func QueryAuthSubsDataProcedure(collName string, ueId string) (map[string]interface{}, *models.ProblemDetails) {
 	filter := bson.M{"ueId": ueId}
 
-	authenticationSubscription, errGetOne := CommonDBClient.RestfulAPIGetOne(collName, filter)
+	authenticationSubscription, errGetOne := AuthDBClient.RestfulAPIGetOne(collName, filter)
 	if errGetOne != nil {
 		logger.DataRepoLog.Warnln(errGetOne)
 	}

--- a/service/init.go
+++ b/service/init.go
@@ -174,7 +174,7 @@ func (udr *UDR) Start() {
 	initLog.Infof("UDR Config Info: Version[%s] Description[%s]", config.Info.Version, config.Info.Description)
 
 	// Connect to MongoDB
-	producer.ConnectMongo(mongodb.Url, mongodb.Name)
+	producer.ConnectMongo(mongodb.Url, mongodb.Name, mongodb.AuthUrl, mongodb.AuthKeysDbName)
 	initLog.Infoln("Server started")
 
 	router := logger_util.NewGinWithLogrus(logger.GinLog)


### PR DESCRIPTION
Storing authentication keys in a separate database by using separate MongoDB clients.
- Aiming to fix https://github.com/omec-project/webconsole/issues/112.
-  Arranging makefile to run the tests
