### PR TITLE
chore: Parameterise webui URL

### DIFF
--- a/factory/config.example.yaml
+++ b/factory/config.example.yaml
@@ -17,6 +17,7 @@ configuration:
     url: http://dummy
     authKeysDbName: authentication
     authUrl: http://dummy
+  webuiUri: webui:9876
   plmnSupportList:
     - plmnId:
         mcc: "208"

--- a/factory/config.go
+++ b/factory/config.go
@@ -42,6 +42,7 @@ type Configuration struct {
 	Sbi             *Sbi              `yaml:"sbi"`
 	Mongodb         *Mongodb          `yaml:"mongodb"`
 	NrfUri          string            `yaml:"nrfUri"`
+	WebuiUri        string            `yaml:"webuiUri"`
 	PlmnSupportList []PlmnSupportItem `yaml:"plmnSupportList,omitempty"`
 }
 

--- a/factory/factory.go
+++ b/factory/factory.go
@@ -57,10 +57,13 @@ func InitConfigFactory(f string) error {
 		if UdrConfig.Configuration.Mongodb.AuthKeysDbName == "" {
 			UdrConfig.Configuration.Mongodb.AuthKeysDbName = "authentication"
 		}
+		if UdrConfig.Configuration.WebuiUri == "" {
+			UdrConfig.Configuration.WebuiUri = "webui:9876"
+		}
 		roc := os.Getenv("MANAGED_BY_CONFIG_POD")
 		if roc == "true" {
 			initLog.Infoln("MANAGED_BY_CONFIG_POD is true")
-			commChannel := client.ConfigWatcher()
+			commChannel := client.ConfigWatcher(UdrConfig.Configuration.WebuiUri)
 			ConfigUpdateDbTrigger = make(chan *UpdateDb, 10)
 			go UdrConfig.updateConfig(commChannel, ConfigUpdateDbTrigger)
 		} else {

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/gin-gonic/gin v1.9.1
 	github.com/google/uuid v1.6.0
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/omec-project/config5g v1.3.0
+	github.com/omec-project/config5g v1.3.1
 	github.com/omec-project/http2_util v1.2.0
 	github.com/omec-project/logger_util v1.2.0
 	github.com/omec-project/openapi v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,8 @@ github.com/montanaflynn/stats v0.6.6 h1:Duep6KMIDpY4Yo11iFsvyqJDyfzLF9+sndUKT+v6
 github.com/montanaflynn/stats v0.6.6/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 h1:W6apQkHrMkS0Muv8G/TipAy/FJl/rCYT0+EuS8+Z0z4=
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
-github.com/omec-project/config5g v1.3.0 h1:e/oMZlQsef8bOpHT56uAMKIag3epCOW0jpmyadFC+30=
-github.com/omec-project/config5g v1.3.0/go.mod h1:h6eaDdWEY7432L9rZAg1Za6HrvFvDWRNolAn5GK/5No=
+github.com/omec-project/config5g v1.3.1 h1:hSvFHXh/J0mslsWR82PPnmpF0WzkmLa6AOdvEPve9e8=
+github.com/omec-project/config5g v1.3.1/go.mod h1:lN/Jc2BZkE/smOGPCXxeo1dJ7s+s9Wgp34crNLH4YeE=
 github.com/omec-project/http2_util v1.2.0 h1:ggQ1GjY2x6VRpKuRhZj0t9dh6eISY6LRBv4rlMD++8s=
 github.com/omec-project/http2_util v1.2.0/go.mod h1:KLgvU3o7qmG/i5XO/qITscFql2tWCAmjE6glX+dxe7M=
 github.com/omec-project/logger_conf v1.1.1 h1:qo0cF5gnPfth8wy+I/QjiOx+F5jB6h4GLSOdyS+ted8=


### PR DESCRIPTION
Config5g library was including the hard coded Webui URL in ConfigWatcher function which is used by several NFs.
PR: https://github.com/omec-project/config5g/pull/35 in Config5G  library allows to change weburi URL. 
Based on that change [this PR](https://github.com/omec-project/udr/pull/70) provides to pass the Weburi URL in UDR. 

Note: https://github.com/omec-project/config5g/pull/35 should be merged before this PR.