### PR TITLE
feat: parametrize paths for TLS certificate and private key

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -36,6 +36,8 @@ type UDRContext struct {
 	Name                                    string
 	UriScheme                               models.UriScheme
 	BindingIPv4                             string
+	Key                                     string
+	PEM                                     string
 	RegisterIPv4                            string // IP register to NRF
 	HttpIPv6Address                         string
 	NfId                                    string

--- a/service/init.go
+++ b/service/init.go
@@ -184,8 +184,6 @@ func (udr *UDR) Start() {
 	go metrics.InitMetrics()
 
 	udrLogPath := util.UdrLogPath
-	udrPemPath := util.UdrPemPath
-	udrKeyPath := util.UdrKeyPath
 
 	self := udr_context.UDR_Self()
 	util.InitUdrContext(self)
@@ -217,7 +215,7 @@ func (udr *UDR) Start() {
 	if serverScheme == "http" {
 		err = server.ListenAndServe()
 	} else if serverScheme == "https" {
-		err = server.ListenAndServeTLS(udrPemPath, udrKeyPath)
+		err = server.ListenAndServeTLS(self.PEM, self.Key)
 	}
 
 	if err != nil {

--- a/util/init_context.go
+++ b/util/init_context.go
@@ -23,6 +23,8 @@ func InitUdrContext(context *udr_context.UDRContext) {
 	context.NfId = uuid.New().String()
 	context.RegisterIPv4 = factory.UDR_DEFAULT_IPV4 // default localhost
 	context.SBIPort = factory.UDR_DEFAULT_PORT_INT  // default port
+	context.Key = UdrKeyPath                        // default key path
+	context.PEM = UdrPemPath                        // default PEM path
 	if sbi := configuration.Sbi; sbi != nil {
 		context.UriScheme = models.UriScheme(sbi.Scheme)
 		if sbi.RegisterIPv4 != "" {
@@ -30,6 +32,14 @@ func InitUdrContext(context *udr_context.UDRContext) {
 		}
 		if sbi.Port != 0 {
 			context.SBIPort = sbi.Port
+		}
+		if tls := sbi.Tls; tls != nil {
+			if tls.Key != "" {
+				context.Key = tls.Key
+			}
+			if tls.Pem != "" {
+				context.PEM = tls.Pem
+			}
 		}
 
 		context.BindingIPv4 = os.Getenv(sbi.BindingIPv4)


### PR DESCRIPTION
This PR adds a `tls` container, composed of `pem` and `key` keys, inside `sbi` container to specify the paths of TLS certificate and private key to use for the HTTPS server.
If the `tls` container is not specified, or `key` or `pem` are not specified, the values are defaulted to maintain backward compatibility.