### PR TITLE
feat: add UDR metrics counters

### DIFF
--- a/datarepository/routers.go
+++ b/datarepository/routers.go
@@ -727,7 +727,7 @@ var subRoutes = Routes{
 		HTTPGetOdbData,
 	},
 
-	// Sepcial case
+	// Special case
 	{
 		"HTTPRemovesubscriptionDataSubscriptions",
 		strings.ToUpper("Delete"),

--- a/metrics/telemetry.go
+++ b/metrics/telemetry.go
@@ -11,8 +11,56 @@ import (
 	"net/http"
 
 	"github.com/omec-project/udr/logger"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
+
+// UdrStats captures UDR stats
+type UdrStats struct {
+	udrSubscriptionData *prometheus.CounterVec
+	udrApplicationData  *prometheus.CounterVec
+	udrPolicyData       *prometheus.CounterVec
+}
+
+var udrStats *UdrStats
+
+func initUdrStats() *UdrStats {
+	return &UdrStats{
+		udrSubscriptionData: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "udr_subscription_data",
+			Help: "Counter of total Subscription data queries",
+		}, []string{"query_type", "resource_type", "result"}),
+		udrApplicationData: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "udr_application_data",
+			Help: "Counter of total Application data queries",
+		}, []string{"query_type", "resource_type", "result"}),
+		udrPolicyData: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "udr_policy_data",
+			Help: "Counter of total Policy data queries",
+		}, []string{"query_type", "resource_type", "result"}),
+	}
+}
+
+func (ps *UdrStats) register() error {
+	if err := prometheus.Register(ps.udrSubscriptionData); err != nil {
+		return err
+	}
+	if err := prometheus.Register(ps.udrApplicationData); err != nil {
+		return err
+	}
+	if err := prometheus.Register(ps.udrPolicyData); err != nil {
+		return err
+	}
+	return nil
+}
+
+func init() {
+	udrStats = initUdrStats()
+
+	if err := udrStats.register(); err != nil {
+		logger.InitLog.Errorln("UDR Stats register failed")
+	}
+}
 
 // InitMetrics initializes UDR metrics
 func InitMetrics() {
@@ -20,4 +68,19 @@ func InitMetrics() {
 	if err := http.ListenAndServe(":8080", nil); err != nil {
 		logger.InitLog.Errorf("Could not open metrics port: %v", err)
 	}
+}
+
+// IncrementUdrSubscriptionDataStats increments number of total Subscription data queries
+func IncrementUdrSubscriptionDataStats(queryType, resourceType, result string) {
+	udrStats.udrSubscriptionData.WithLabelValues(queryType, resourceType, result).Inc()
+}
+
+// IncrementUdrApplicationDataStats increments number of total Application data queries
+func IncrementUdrApplicationDataStats(queryType, resourceType, result string) {
+	udrStats.udrApplicationData.WithLabelValues(queryType, resourceType, result).Inc()
+}
+
+// IncrementUdrPolicyDataStats increments number of total Policy data queries
+func IncrementUdrPolicyDataStats(queryType, resourceType, result string) {
+	udrStats.udrPolicyData.WithLabelValues(queryType, resourceType, result).Inc()
 }

--- a/producer/data_repository.go
+++ b/producer/data_repository.go
@@ -56,12 +56,12 @@ func getDataFromDB(collName string, filter bson.M) (map[string]interface{}, *mod
 	return data, nil
 }
 
-func deleteDataFromDB(collName string, filter bson.M) *error {
+func deleteDataFromDB(collName string, filter bson.M) error {
 	errDelOne := CommonDBClient.RestfulAPIDeleteOne(collName, filter)
 	if errDelOne != nil {
 		logger.DataRepoLog.Warnln(errDelOne)
 	}
-	return &errDelOne
+	return errDelOne
 }
 
 func HandleCreateAccessAndMobilityData(request *httpwrapper.Request) *httpwrapper.Response {
@@ -239,7 +239,7 @@ func HandleCreateAmfContext3gpp(request *httpwrapper.Request) *httpwrapper.Respo
 
 func CreateAmfContext3gppProcedure(collName string, ueId string,
 	Amf3GppAccessRegistration models.Amf3GppAccessRegistration,
-) *error {
+) error {
 	filter := bson.M{"ueId": ueId}
 	putData := util.ToBsonM(Amf3GppAccessRegistration)
 	putData["ueId"] = ueId
@@ -248,7 +248,7 @@ func CreateAmfContext3gppProcedure(collName string, ueId string,
 	if errPutOne != nil {
 		logger.DataRepoLog.Warnln(errPutOne)
 	}
-	return &errPutOne
+	return errPutOne
 }
 
 func HandleQueryAmfContext3gpp(request *httpwrapper.Request) *httpwrapper.Response {
@@ -348,7 +348,7 @@ func HandleCreateAmfContextNon3gpp(request *httpwrapper.Request) *httpwrapper.Re
 
 func CreateAmfContextNon3gppProcedure(AmfNon3GppAccessRegistration models.AmfNon3GppAccessRegistration,
 	collName string, ueId string,
-) *error {
+) error {
 	putData := util.ToBsonM(AmfNon3GppAccessRegistration)
 	putData["ueId"] = ueId
 	filter := bson.M{"ueId": ueId}
@@ -357,7 +357,7 @@ func CreateAmfContextNon3gppProcedure(AmfNon3GppAccessRegistration models.AmfNon
 	if errPutOne != nil {
 		logger.DataRepoLog.Warnln(errPutOne)
 	}
-	return &errPutOne
+	return errPutOne
 }
 
 func HandleQueryAmfContextNon3gpp(request *httpwrapper.Request) *httpwrapper.Response {
@@ -490,7 +490,7 @@ func HandleCreateAuthenticationSoR(request *httpwrapper.Request) *httpwrapper.Re
 	return httpwrapper.NewResponse(http.StatusNoContent, nil, map[string]interface{}{})
 }
 
-func CreateAuthenticationSoRProcedure(collName string, ueId string, putData bson.M) *error {
+func CreateAuthenticationSoRProcedure(collName string, ueId string, putData bson.M) error {
 	filter := bson.M{"ueId": ueId}
 	putData["ueId"] = ueId
 
@@ -498,7 +498,7 @@ func CreateAuthenticationSoRProcedure(collName string, ueId string, putData bson
 	if errPutOne != nil {
 		logger.DataRepoLog.Warnln(errPutOne)
 	}
-	return &errPutOne
+	return errPutOne
 }
 
 func HandleQueryAuthSoR(request *httpwrapper.Request) *httpwrapper.Response {
@@ -554,7 +554,7 @@ func HandleCreateAuthenticationStatus(request *httpwrapper.Request) *httpwrapper
 	return httpwrapper.NewResponse(http.StatusNoContent, nil, map[string]interface{}{})
 }
 
-func CreateAuthenticationStatusProcedure(collName string, ueId string, putData bson.M) *error {
+func CreateAuthenticationStatusProcedure(collName string, ueId string, putData bson.M) error {
 	filter := bson.M{"ueId": ueId}
 	putData["ueId"] = ueId
 
@@ -562,7 +562,7 @@ func CreateAuthenticationStatusProcedure(collName string, ueId string, putData b
 	if errPutOne != nil {
 		logger.DataRepoLog.Warnln(errPutOne)
 	}
-	return &errPutOne
+	return errPutOne
 }
 
 func HandleQueryAuthenticationStatus(request *httpwrapper.Request) *httpwrapper.Response {
@@ -1133,13 +1133,13 @@ func HandlePolicyDataBdtDataBdtReferenceIdDelete(request *httpwrapper.Request) *
 	return httpwrapper.NewResponse(http.StatusNoContent, nil, map[string]interface{}{})
 }
 
-func PolicyDataBdtDataBdtReferenceIdDeleteProcedure(collName string, bdtReferenceId string) *error {
+func PolicyDataBdtDataBdtReferenceIdDeleteProcedure(collName string, bdtReferenceId string) error {
 	filter := bson.M{"bdtReferenceId": bdtReferenceId}
 	errDelOne := CommonDBClient.RestfulAPIDeleteOne(collName, filter)
 	if errDelOne != nil {
 		logger.DataRepoLog.Warnln(errDelOne)
 	}
-	return &errDelOne
+	return errDelOne
 }
 
 func HandlePolicyDataBdtDataBdtReferenceIdGet(request *httpwrapper.Request) *httpwrapper.Response {
@@ -1533,7 +1533,7 @@ func HandlePolicyDataUesUeIdOperatorSpecificDataPut(request *httpwrapper.Request
 
 func PolicyDataUesUeIdOperatorSpecificDataPutProcedure(collName string, ueId string,
 	OperatorSpecificDataContainer map[string]models.OperatorSpecificDataContainer,
-) *error {
+) error {
 	filter := bson.M{"ueId": ueId}
 
 	putData := map[string]interface{}{"operatorSpecificDataContainerMap": OperatorSpecificDataContainer}
@@ -1543,7 +1543,7 @@ func PolicyDataUesUeIdOperatorSpecificDataPutProcedure(collName string, ueId str
 	if errPutOne != nil {
 		logger.DataRepoLog.Warnln(errPutOne)
 	}
-	return &errPutOne
+	return errPutOne
 }
 
 func HandlePolicyDataUesUeIdSmDataGet(request *httpwrapper.Request) *httpwrapper.Response {
@@ -1717,13 +1717,13 @@ func HandlePolicyDataUesUeIdSmDataUsageMonIdDelete(request *httpwrapper.Request)
 	return httpwrapper.NewResponse(http.StatusNoContent, nil, map[string]interface{}{})
 }
 
-func PolicyDataUesUeIdSmDataUsageMonIdDeleteProcedure(collName string, ueId string, usageMonId string) *error {
+func PolicyDataUesUeIdSmDataUsageMonIdDeleteProcedure(collName string, ueId string, usageMonId string) error {
 	filter := bson.M{"ueId": ueId, "usageMonId": usageMonId}
 	errDelOne := CommonDBClient.RestfulAPIDeleteOne(collName, filter)
 	if errDelOne != nil {
 		logger.DataRepoLog.Warnln(errDelOne)
 	}
-	return &errDelOne
+	return errDelOne
 }
 
 func HandlePolicyDataUesUeIdSmDataUsageMonIdGet(request *httpwrapper.Request) *httpwrapper.Response {

--- a/producer/data_repository.go
+++ b/producer/data_repository.go
@@ -931,15 +931,19 @@ func HandleApplicationDataInfluenceDataSubsToNotifySubscriptionIdDelete(subscID 
 	logger.DataRepoLog.Infof(
 		"handle ApplicationDataInfluenceDataSubsToNotifySubscriptionIdDelete: subscID=%q", subscID)
 
-	deleteApplicationDataIndividualInfluenceDataSubsToNotifyFromDB(subscID)
-	stats.IncrementUdrApplicationDataStats("delete", "influence-data-subscription", "SUCCESS")
+	err := deleteApplicationDataIndividualInfluenceDataSubsToNotifyFromDB(subscID)
+	if err == nil {
+		stats.IncrementUdrApplicationDataStats("delete", "influence-data-subscription", "SUCCESS")
+	} else {
+		stats.IncrementUdrApplicationDataStats("delete", "influence-data-subscription", "FAILURE")
+	}
 
 	return httpwrapper.NewResponse(http.StatusNoContent, nil, map[string]interface{}{})
 }
 
-func deleteApplicationDataIndividualInfluenceDataSubsToNotifyFromDB(subscID string) {
+func deleteApplicationDataIndividualInfluenceDataSubsToNotifyFromDB(subscID string) error {
 	filter := bson.M{"subscriptionId": subscID}
-	deleteDataFromDB(APPDATA_INFLUDATA_SUBSC_DB_COLLECTION_NAME, filter)
+	return deleteDataFromDB(APPDATA_INFLUDATA_SUBSC_DB_COLLECTION_NAME, filter)
 }
 
 func HandleApplicationDataInfluenceDataSubsToNotifySubscriptionIdGet(subscID string) *httpwrapper.Response {
@@ -1011,14 +1015,18 @@ func putApplicationDataIndividualInfluenceDataSubsToNotifyToDB(subscID string,
 func HandleApplicationDataPfdsAppIdDelete(appID string) *httpwrapper.Response {
 	logger.DataRepoLog.Infof("handle ApplicationDataPfdsAppIdDelete: appID=%s", appID)
 
-	deleteApplicationDataIndividualPfdFromDB(appID)
-	stats.IncrementUdrApplicationDataStats("delete", "pfds", "SUCCESS")
+	err := deleteApplicationDataIndividualPfdFromDB(appID)
+	if err == nil {
+		stats.IncrementUdrApplicationDataStats("delete", "pfds", "SUCCESS")
+	} else {
+		stats.IncrementUdrApplicationDataStats("delete", "pfds", "FAILURE")
+	}
 	return httpwrapper.NewResponse(http.StatusNoContent, nil, map[string]interface{}{})
 }
 
-func deleteApplicationDataIndividualPfdFromDB(appID string) {
+func deleteApplicationDataIndividualPfdFromDB(appID string) error {
 	filter := bson.M{"applicationId": appID}
-	deleteDataFromDB(APPDATA_PFD_DB_COLLECTION_NAME, filter)
+	return deleteDataFromDB(APPDATA_PFD_DB_COLLECTION_NAME, filter)
 }
 
 func HandleApplicationDataPfdsAppIdGet(appID string) *httpwrapper.Response {

--- a/producer/data_repository.go
+++ b/producer/data_repository.go
@@ -267,7 +267,7 @@ func HandleQueryAmfContext3gpp(request *httpwrapper.Request) *httpwrapper.Respon
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 
-	pd := util.ProblemDetailsUpspecified("")
+	pd := util.ProblemDetailsUnspecified("")
 	return httpwrapper.NewResponse(int(pd.Status), nil, pd)
 }
 
@@ -376,7 +376,7 @@ func HandleQueryAmfContextNon3gpp(request *httpwrapper.Request) *httpwrapper.Res
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 
-	pd := util.ProblemDetailsUpspecified("")
+	pd := util.ProblemDetailsUnspecified("")
 	stats.IncrementUdrSubscriptionDataStats("get", "amf-non-3gpp-access", "FAILURE")
 	return httpwrapper.NewResponse(int(pd.Status), nil, pd)
 }
@@ -454,7 +454,7 @@ func HandleQueryAuthSubsData(request *httpwrapper.Request) *httpwrapper.Response
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 
-	pd := util.ProblemDetailsUpspecified("")
+	pd := util.ProblemDetailsUnspecified("")
 	stats.IncrementUdrSubscriptionDataStats("update", "authentication-subscription", "FAILURE")
 	return httpwrapper.NewResponse(int(pd.Status), nil, pd)
 }
@@ -517,7 +517,7 @@ func HandleQueryAuthSoR(request *httpwrapper.Request) *httpwrapper.Response {
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 
-	pd := util.ProblemDetailsUpspecified("")
+	pd := util.ProblemDetailsUnspecified("")
 	stats.IncrementUdrSubscriptionDataStats("get", "sor-data", "FAILURE")
 	return httpwrapper.NewResponse(int(pd.Status), nil, pd)
 }
@@ -581,7 +581,7 @@ func HandleQueryAuthenticationStatus(request *httpwrapper.Request) *httpwrapper.
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 
-	pd := util.ProblemDetailsUpspecified("")
+	pd := util.ProblemDetailsUnspecified("")
 	stats.IncrementUdrSubscriptionDataStats("get", "authentication-status", "FAILURE")
 	return httpwrapper.NewResponse(int(pd.Status), nil, pd)
 }
@@ -1157,7 +1157,7 @@ func HandlePolicyDataBdtDataBdtReferenceIdGet(request *httpwrapper.Request) *htt
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 
-	pd := util.ProblemDetailsUpspecified("")
+	pd := util.ProblemDetailsUnspecified("")
 	stats.IncrementUdrPolicyDataStats("get", "bdt-data", "FAILURE")
 	return httpwrapper.NewResponse(int(pd.Status), nil, pd)
 }
@@ -1192,7 +1192,7 @@ func HandlePolicyDataBdtDataBdtReferenceIdPut(request *httpwrapper.Request) *htt
 		return httpwrapper.NewResponse(http.StatusOK, nil, response)
 	}
 
-	pd := util.ProblemDetailsUpspecified("")
+	pd := util.ProblemDetailsUnspecified("")
 	stats.IncrementUdrPolicyDataStats("update", "bdt-data", "FAILURE")
 	return httpwrapper.NewResponse(int(pd.Status), nil, pd)
 }
@@ -1252,7 +1252,7 @@ func HandlePolicyDataPlmnsPlmnIdUePolicySetGet(request *httpwrapper.Request) *ht
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 
-	pd := util.ProblemDetailsUpspecified("")
+	pd := util.ProblemDetailsUnspecified("")
 	stats.IncrementUdrPolicyDataStats("get", "plmn-ue-policy-set", "FAILURE")
 	return httpwrapper.NewResponse(int(pd.Status), nil, pd)
 }
@@ -1289,7 +1289,7 @@ func HandlePolicyDataSponsorConnectivityDataSponsorIdGet(request *httpwrapper.Re
 		return httpwrapper.NewResponse(http.StatusNoContent, nil, map[string]interface{}{})
 	}
 
-	pd := util.ProblemDetailsUpspecified("")
+	pd := util.ProblemDetailsUnspecified("")
 	stats.IncrementUdrPolicyDataStats("get", "sponsor-connectivity-data", "FAILURE")
 	return httpwrapper.NewResponse(int(pd.Status), nil, pd)
 }
@@ -1413,7 +1413,7 @@ func HandlePolicyDataUesUeIdAmDataGet(request *httpwrapper.Request) *httpwrapper
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 
-	pd := util.ProblemDetailsUpspecified("")
+	pd := util.ProblemDetailsUnspecified("")
 	stats.IncrementUdrPolicyDataStats("get", "am-data", "FAILURE")
 	return httpwrapper.NewResponse(int(pd.Status), nil, pd)
 }
@@ -1451,7 +1451,7 @@ func HandlePolicyDataUesUeIdOperatorSpecificDataGet(request *httpwrapper.Request
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 
-	pd := util.ProblemDetailsUpspecified("")
+	pd := util.ProblemDetailsUnspecified("")
 	stats.IncrementUdrPolicyDataStats("get", "operator-specific-data", "FAILURE")
 	return httpwrapper.NewResponse(int(pd.Status), nil, pd)
 }
@@ -1568,7 +1568,7 @@ func HandlePolicyDataUesUeIdSmDataGet(request *httpwrapper.Request) *httpwrapper
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 
-	pd := util.ProblemDetailsUpspecified("")
+	pd := util.ProblemDetailsUnspecified("")
 	stats.IncrementUdrPolicyDataStats("get", "sm-data", "FAILURE")
 	return httpwrapper.NewResponse(int(pd.Status), nil, pd)
 }
@@ -1802,7 +1802,7 @@ func HandlePolicyDataUesUeIdUePolicySetGet(request *httpwrapper.Request) *httpwr
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 
-	pd := util.ProblemDetailsUpspecified("")
+	pd := util.ProblemDetailsUnspecified("")
 	stats.IncrementUdrPolicyDataStats("get", "ue-policy-set", "FAILURE")
 	return httpwrapper.NewResponse(int(pd.Status), nil, pd)
 }
@@ -1885,7 +1885,7 @@ func HandlePolicyDataUesUeIdUePolicySetPut(request *httpwrapper.Request) *httpwr
 		return httpwrapper.NewResponse(http.StatusCreated, nil, response)
 	}
 
-	pd := util.ProblemDetailsUpspecified("")
+	pd := util.ProblemDetailsUnspecified("")
 	stats.IncrementUdrPolicyDataStats("create", "ue-policy-set", "FAILURE")
 	return httpwrapper.NewResponse(int(pd.Status), nil, pd)
 }
@@ -2069,7 +2069,7 @@ func HandleGetAmfSubscriptionInfo(request *httpwrapper.Request) *httpwrapper.Res
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 
-	pd := util.ProblemDetailsUpspecified("")
+	pd := util.ProblemDetailsUnspecified("")
 	stats.IncrementUdrSubscriptionDataStats("get", "amf-subscriptions", "FAILURE")
 	return httpwrapper.NewResponse(int(pd.Status), nil, pd)
 }
@@ -2113,7 +2113,7 @@ func HandleQueryEEData(request *httpwrapper.Request) *httpwrapper.Response {
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 
-	pd := util.ProblemDetailsUpspecified("")
+	pd := util.ProblemDetailsUnspecified("")
 	stats.IncrementUdrSubscriptionDataStats("get", "ee-profile-data", "FAILURE")
 	return httpwrapper.NewResponse(int(pd.Status), nil, pd)
 }
@@ -2259,7 +2259,7 @@ func HandleQueryEeGroupSubscriptions(request *httpwrapper.Request) *httpwrapper.
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 
-	pd := util.ProblemDetailsUpspecified("")
+	pd := util.ProblemDetailsUnspecified("")
 	stats.IncrementUdrSubscriptionDataStats("get", "group-data", "FAILURE")
 	return httpwrapper.NewResponse(int(pd.Status), nil, pd)
 }
@@ -2408,7 +2408,7 @@ func HandleQueryeesubscriptions(request *httpwrapper.Request) *httpwrapper.Respo
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 
-	pd := util.ProblemDetailsUpspecified("")
+	pd := util.ProblemDetailsUnspecified("")
 	stats.IncrementUdrSubscriptionDataStats("get", "ee-subscriptions", "FAILURE")
 	return httpwrapper.NewResponse(int(pd.Status), nil, pd)
 }
@@ -2491,7 +2491,7 @@ func HandleQueryOperSpecData(request *httpwrapper.Request) *httpwrapper.Response
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 
-	pd := util.ProblemDetailsUpspecified("")
+	pd := util.ProblemDetailsUnspecified("")
 	stats.IncrementUdrPolicyDataStats("get", "operator-specific-data", "FAILURE")
 	return httpwrapper.NewResponse(int(pd.Status), nil, pd)
 }
@@ -2529,7 +2529,7 @@ func HandleGetppData(request *httpwrapper.Request) *httpwrapper.Response {
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 
-	pd := util.ProblemDetailsUpspecified("")
+	pd := util.ProblemDetailsUnspecified("")
 	stats.IncrementUdrSubscriptionDataStats("get", "pp-data", "FAILURE")
 	return httpwrapper.NewResponse(int(pd.Status), nil, pd)
 }
@@ -2578,7 +2578,7 @@ func HandleQueryProvisionedData(request *httpwrapper.Request) *httpwrapper.Respo
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 
-	pd := util.ProblemDetailsUpspecified("")
+	pd := util.ProblemDetailsUnspecified("")
 	stats.IncrementUdrSubscriptionDataStats("get", "provisioned-data", "FAILURE")
 	return httpwrapper.NewResponse(int(pd.Status), nil, pd)
 }
@@ -2755,7 +2755,7 @@ func HandleGetIdentityData(request *httpwrapper.Request) *httpwrapper.Response {
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 
-	pd := util.ProblemDetailsUpspecified("")
+	pd := util.ProblemDetailsUnspecified("")
 	stats.IncrementUdrSubscriptionDataStats("get", "identity-data", "FAILURE")
 	return httpwrapper.NewResponse(int(pd.Status), nil, pd)
 }
@@ -2791,7 +2791,7 @@ func HandleGetOdbData(request *httpwrapper.Request) *httpwrapper.Response {
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 
-	pd := util.ProblemDetailsUpspecified("")
+	pd := util.ProblemDetailsUnspecified("")
 	stats.IncrementUdrSubscriptionDataStats("get", "operator-determined-barring-data", "FAILURE")
 	return httpwrapper.NewResponse(int(pd.Status), nil, pd)
 }
@@ -2833,7 +2833,7 @@ func HandleGetSharedData(request *httpwrapper.Request) *httpwrapper.Response {
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 
-	pd := util.ProblemDetailsUpspecified("")
+	pd := util.ProblemDetailsUnspecified("")
 	stats.IncrementUdrSubscriptionDataStats("get", "shared-data", "FAILURE")
 	return httpwrapper.NewResponse(int(pd.Status), nil, pd)
 }
@@ -2992,7 +2992,7 @@ func HandleQuerysdmsubscriptions(request *httpwrapper.Request) *httpwrapper.Resp
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 
-	pd := util.ProblemDetailsUpspecified("")
+	pd := util.ProblemDetailsUnspecified("")
 	stats.IncrementUdrSubscriptionDataStats("get", "sdm-subscriptions", "FAILURE")
 	return httpwrapper.NewResponse(int(pd.Status), nil, pd)
 }
@@ -3080,7 +3080,7 @@ func HandleCreateSmfContextNon3gpp(request *httpwrapper.Request) *httpwrapper.Re
 		return httpwrapper.NewResponse(http.StatusOK, nil, response)
 	}
 
-	pd := util.ProblemDetailsUpspecified("")
+	pd := util.ProblemDetailsUnspecified("")
 	stats.IncrementUdrSubscriptionDataStats("create", "smf-registrations", "FAILURE")
 	return httpwrapper.NewResponse(int(pd.Status), nil, pd)
 }
@@ -3146,7 +3146,7 @@ func HandleQuerySmfRegistration(request *httpwrapper.Request) *httpwrapper.Respo
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 
-	pd := util.ProblemDetailsUpspecified("")
+	pd := util.ProblemDetailsUnspecified("")
 	stats.IncrementUdrSubscriptionDataStats("get", "smf-registrations", "FAILURE")
 	return httpwrapper.NewResponse(int(pd.Status), nil, pd)
 }
@@ -3293,7 +3293,7 @@ func HandleQuerySmsfContext3gpp(request *httpwrapper.Request) *httpwrapper.Respo
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 
-	pd := util.ProblemDetailsUpspecified("")
+	pd := util.ProblemDetailsUnspecified("")
 	stats.IncrementUdrSubscriptionDataStats("get", "smsf-3gpp-access", "FAILURE")
 	return httpwrapper.NewResponse(int(pd.Status), nil, pd)
 }
@@ -3370,7 +3370,7 @@ func HandleQuerySmsfContextNon3gpp(request *httpwrapper.Request) *httpwrapper.Re
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 
-	pd := util.ProblemDetailsUpspecified("")
+	pd := util.ProblemDetailsUnspecified("")
 	stats.IncrementUdrSubscriptionDataStats("get", "smsf-non-3gpp-access", "FAILURE")
 	return httpwrapper.NewResponse(int(pd.Status), nil, pd)
 }
@@ -3406,7 +3406,7 @@ func HandleQuerySmsMngData(request *httpwrapper.Request) *httpwrapper.Response {
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 
-	pd := util.ProblemDetailsUpspecified("")
+	pd := util.ProblemDetailsUnspecified("")
 	stats.IncrementUdrSubscriptionDataStats("get", "sms-mng-data", "FAILURE")
 	return httpwrapper.NewResponse(int(pd.Status), nil, pd)
 }
@@ -3444,7 +3444,7 @@ func HandleQuerySmsData(request *httpwrapper.Request) *httpwrapper.Response {
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 
-	pd := util.ProblemDetailsUpspecified("")
+	pd := util.ProblemDetailsUnspecified("")
 	stats.IncrementUdrSubscriptionDataStats("get", "sms-data", "FAILURE")
 	return httpwrapper.NewResponse(int(pd.Status), nil, pd)
 }
@@ -3539,7 +3539,7 @@ func HandleQueryTraceData(request *httpwrapper.Request) *httpwrapper.Response {
 		return httpwrapper.NewResponse(int(problemDetails.Status), nil, problemDetails)
 	}
 
-	pd := util.ProblemDetailsUpspecified("")
+	pd := util.ProblemDetailsUnspecified("")
 	stats.IncrementUdrSubscriptionDataStats("get", "trace-data", "FAILURE")
 	return httpwrapper.NewResponse(int(pd.Status), nil, pd)
 }

--- a/service/init.go
+++ b/service/init.go
@@ -309,7 +309,7 @@ func (udr *UDR) StopKeepAliveTimer() {
 func (udr *UDR) BuildAndSendRegisterNFInstance() (prof models.NfProfile, err error) {
 	self := context.UDR_Self()
 	profile := consumer.BuildNFInstance(self)
-	initLog.Infof("pcf Profile Registering to NRF: %v", profile)
+	initLog.Infof("udr Profile Registering to NRF: %v", profile)
 	// Indefinite attempt to register until success
 	profile, _, self.NfId, err = consumer.SendRegisterNFInstance(self.NrfUri, self.NfId, profile)
 	return profile, err

--- a/util/util.go
+++ b/util/util.go
@@ -55,7 +55,7 @@ func ProblemDetailsModifyNotAllowed(detail string) *models.ProblemDetails {
 	}
 }
 
-func ProblemDetailsUpspecified(detail string) *models.ProblemDetails {
+func ProblemDetailsUnspecified(detail string) *models.ProblemDetails {
 	return &models.ProblemDetails{
 		Title:  "Unspecified",
 		Status: http.StatusForbidden,


### PR DESCRIPTION
This PR adds three new 5G specific metrics, `udr_subscription_data`, `udr_application_data` and `udr_policy_data` to exported metrics via Prometheus.
The scope of the metrics is the following:
* `udr_subscription_data`: this metric counts the total number of Subscription data queries to UDR; the metric stores the query type (`create`, `get`, `update`, `delete`), the resource type and the result (`SUCCESS`, `FAILURE`);
* `udr_application_data`: this metric counts the total number of Application data queries to UDR; the metric stores the query type (`create`, `get`, `update`, `delete`), the resource type and the result (`SUCCESS`, `FAILURE`);
* `udr_policy_data`: this metric counts the total number of Policy data queries to UDR; the metric stores the query type (`create`, `get`, `update`, `delete`), the resource type and the result (`SUCCESS`, `FAILURE`).