### PR TITLE
chore: enable static check and govet in ci

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,15 +21,15 @@ linters:
     - goconst
     - godox
     - gomodguard
+    - govet
     - misspell
     - nakedret
     - noctx
     - predeclared
+    - staticcheck
     - unconvert
     - whitespace
   disable:
-    - govet
-    - staticcheck
   settings:
     errcheck:
       check-type-assertions: false
@@ -63,6 +63,8 @@ linters:
         - XXX
     govet:
       enable-all: true
+      disable:
+        - fieldalignment
       settings:
         printf:
           funcs:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,7 +29,6 @@ linters:
     - staticcheck
     - unconvert
     - whitespace
-  disable:
   settings:
     errcheck:
       check-type-assertions: false

--- a/consumer/nf_managemant.go
+++ b/consumer/nf_managemant.go
@@ -96,16 +96,17 @@ var SendRegisterNFInstance = func(nrfUri, nfInstanceId string, profile models.Nf
 		}()
 
 		status := res.StatusCode
-		if status == http.StatusOK {
+		switch status {
+		case http.StatusOK:
 			// NFUpdate
 			return prof, resouceNrfUri, retrieveNfInstanceId, err
-		} else if status == http.StatusCreated {
+		case http.StatusCreated:
 			// NFRegister
 			resourceUri := res.Header.Get("Location")
 			resouceNrfUri = resourceUri[:strings.Index(resourceUri, "/nnrf-nfm/")]
 			retrieveNfInstanceId = resourceUri[strings.LastIndex(resourceUri, "/")+1:]
 			return prof, resouceNrfUri, retrieveNfInstanceId, err
-		} else {
+		default:
 			logger.ConsumerLog.Errorln("handler returned wrong status code", status)
 			logger.ConsumerLog.Errorln("NRF return wrong status code", status)
 		}

--- a/factory/config.go
+++ b/factory/config.go
@@ -122,7 +122,7 @@ func (c *Config) UpdateConfig(commChannel chan *protos.NetworkSliceResponse, dbU
 					plmn := PlmnSupportItem{}
 					plmn.PlmnId.Mnc = site.Plmn.Mnc
 					plmn.PlmnId.Mcc = site.Plmn.Mcc
-					var found bool = false
+					found := false
 					for _, cplmn := range UdrConfig.Configuration.PlmnSupportList {
 						if (cplmn.PlmnId.Mnc == plmn.PlmnId.Mnc) && (cplmn.PlmnId.Mcc == plmn.PlmnId.Mcc) {
 							found = true

--- a/producer/data_repository.go
+++ b/producer/data_repository.go
@@ -1289,10 +1289,11 @@ func HandlePolicyDataSponsorConnectivityDataSponsorIdGet(request *httpwrapper.Re
 
 	response, status := PolicyDataSponsorConnectivityDataSponsorIdGetProcedure(collName, sponsorId)
 
-	if status == http.StatusOK {
+	switch status {
+	case http.StatusOK:
 		stats.IncrementUdrPolicyDataStats("get", "sponsor-connectivity-data", "SUCCESS")
 		return httpwrapper.NewResponse(http.StatusOK, nil, response)
-	} else if status == http.StatusNoContent {
+	case http.StatusNoContent:
 		stats.IncrementUdrPolicyDataStats("get", "sponsor-connectivity-data", "SUCCESS")
 		return httpwrapper.NewResponse(http.StatusNoContent, nil, map[string]interface{}{})
 	}
@@ -1885,10 +1886,11 @@ func HandlePolicyDataUesUeIdUePolicySetPut(request *httpwrapper.Request) *httpwr
 
 	response, status := PolicyDataUesUeIdUePolicySetPutProcedure(collName, ueId, UePolicySet)
 
-	if status == http.StatusNoContent {
+	switch status {
+	case http.StatusNoContent:
 		stats.IncrementUdrPolicyDataStats("create", "ue-policy-set", "SUCCESS")
 		return httpwrapper.NewResponse(http.StatusNoContent, nil, map[string]interface{}{})
-	} else if status == http.StatusCreated {
+	case http.StatusCreated:
 		stats.IncrementUdrPolicyDataStats("create", "ue-policy-set", "SUCCESS")
 		return httpwrapper.NewResponse(http.StatusCreated, nil, response)
 	}
@@ -3080,10 +3082,11 @@ func HandleCreateSmfContextNon3gpp(request *httpwrapper.Request) *httpwrapper.Re
 
 	response, status := CreateSmfContextNon3gppProcedure(SmfRegistration, collName, ueId, pduSessionId)
 
-	if status == http.StatusCreated {
+	switch status {
+	case http.StatusCreated:
 		stats.IncrementUdrSubscriptionDataStats("create", "smf-registrations", "SUCCESS")
 		return httpwrapper.NewResponse(http.StatusCreated, nil, response)
-	} else if status == http.StatusOK {
+	case http.StatusOK:
 		stats.IncrementUdrSubscriptionDataStats("create", "smf-registrations", "SUCCESS")
 		return httpwrapper.NewResponse(http.StatusOK, nil, response)
 	}

--- a/service/init.go
+++ b/service/init.go
@@ -249,10 +249,14 @@ func (udr *UDR) Start() {
 	}
 
 	serverScheme := factory.UdrConfig.Configuration.Sbi.Scheme
-	if serverScheme == "http" {
+	switch serverScheme {
+	case "http":
 		err = server.ListenAndServe()
-	} else if serverScheme == "https" {
+	case "https":
 		err = server.ListenAndServeTLS(self.PEM, self.Key)
+	default:
+		logger.InitLog.Fatalf("HTTP server setup failed: invalid server scheme %+v", serverScheme)
+		return
 	}
 
 	if err != nil {

--- a/util/util.go
+++ b/util/util.go
@@ -30,13 +30,14 @@ func ProblemDetailsMalformedReqSyntax(detail string) *models.ProblemDetails {
 
 func ProblemDetailsNotFound(cause string) *models.ProblemDetails {
 	title := ""
-	if cause == "USER_NOT_FOUND" {
+	switch cause {
+	case "USER_NOT_FOUND":
 		title = "User not found"
-	} else if cause == "SUBSCRIPTION_NOT_FOUND" {
+	case "SUBSCRIPTION_NOT_FOUND":
 		title = "Subscription not found"
-	} else if cause == "AMFSUBSCRIPTION_NOT_FOUND" {
+	case "AMFSUBSCRIPTION_NOT_FOUND":
 		title = "AMF Subscription not found"
-	} else {
+	default:
 		title = "Data not found"
 	}
 	return &models.ProblemDetails{


### PR DESCRIPTION
this PR enables `staticcheck` and `govet` in the CI

- fix a variable declaration
- replace if with switch

govet's `fieldaligment` remains disabled