### PR TITLE
Support for Multiple DNNs per Device Group with a Single UPF

### DIFF
--- a/factory/config.go
+++ b/factory/config.go
@@ -11,7 +11,7 @@
 package factory
 
 import (
-	protos "github.com/omec-project/config5g/proto/sdcoreConfig"
+	protos "github.com/5GC-DEV/config5g-cdac/proto/sdcoreConfig"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/udr/logger"
 	utilLogger "github.com/omec-project/util/logger"
@@ -93,15 +93,18 @@ func (c *Config) GetVersion() string {
 func (c *Config) addSmPolicyInfo(nwSlice *protos.NetworkSlice, dbUpdateChannel chan *UpdateDb) error {
 	for _, devGrp := range nwSlice.DeviceGroup {
 		for _, imsi := range devGrp.Imsi {
-			smPolicyEntry := &SmPolicyUpdateEntry{
-				Imsi:   imsi,
-				Dnn:    devGrp.IpDomainDetails.DnnName,
-				Snssai: nwSlice.Nssai,
+			// Iterate over the IpDomainDetails slice
+			for _, ipDomain := range devGrp.IpDomainDetails {
+				smPolicyEntry := &SmPolicyUpdateEntry{
+					Imsi:   imsi,
+					Dnn:    ipDomain.DnnName, // Access DnnName from the IpDomain struct
+					Snssai: nwSlice.Nssai,
+				}
+				dbUpdate := &UpdateDb{
+					SmPolicyTable: smPolicyEntry,
+				}
+				dbUpdateChannel <- dbUpdate
 			}
-			dbUpdate := &UpdateDb{
-				SmPolicyTable: smPolicyEntry,
-			}
-			dbUpdateChannel <- dbUpdate
 		}
 	}
 	return nil

--- a/factory/factory.go
+++ b/factory/factory.go
@@ -14,7 +14,7 @@ import (
 	"fmt"
 	"os"
 
-	protos "github.com/omec-project/config5g/proto/sdcoreConfig"
+	protos "github.com/5GC-DEV/config5g-cdac/proto/sdcoreConfig"
 	"github.com/omec-project/udr/logger"
 	"gopkg.in/yaml.v2"
 )

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/gin-gonic/gin v1.10.1
 	github.com/google/uuid v1.6.0
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/omec-project/config5g v1.6.2
 	github.com/omec-project/openapi v1.4.1
 	github.com/omec-project/util v1.3.2
 	github.com/prometheus/client_golang v1.22.0
@@ -19,6 +18,7 @@ require (
 )
 
 require (
+	github.com/5GC-DEV/config5g-cdac v0.2.1 // indirect
 	github.com/antihax/optional v1.0.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/5GC-DEV/config5g-cdac v0.2.1 h1:7Cqwmqh5jqeWtwYTrITflrGotglIRBIb1P3EF2f85OA=
+github.com/5GC-DEV/config5g-cdac v0.2.1/go.mod h1:0OEL6UoNKKlx2tlNSoKpRtzckwxR2SL+pRBDAOCT4BU=
 github.com/antihax/optional v1.0.0 h1:xK2lYat7ZLaVVcIuj82J8kIro4V6kDe0AUDFboUCwcg=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
@@ -83,8 +85,6 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 h1:W6apQkHrMkS0Muv8G/TipAy/FJl/rCYT0+EuS8+Z0z4=
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
-github.com/omec-project/config5g v1.6.2 h1:bfLxwVSt6LAWCQtBmjUuks5CO3qambvcy3VjSVAMHdk=
-github.com/omec-project/config5g v1.6.2/go.mod h1:LuaRiJTCJXCkQF7nKB5fOcz6oVMF/8oid+EKCYFAy0E=
 github.com/omec-project/openapi v1.4.1 h1:F9RAjS5at/xcd2Iadl4/V0I3veYnH2WiFc3B7bj6Y8k=
 github.com/omec-project/openapi v1.4.1/go.mod h1:RVoo/FjKWlqg95hRRqBhQYzoCUZlE+h6/u4vj8bP2Jo=
 github.com/omec-project/util v1.3.2 h1:5JP4ZYqMPPESSYrgc6LQNlcvJ/Xhrq8u5jSV405iuX8=

--- a/service/init.go
+++ b/service/init.go
@@ -18,8 +18,8 @@ import (
 	"syscall"
 	"time"
 
-	grpcClient "github.com/omec-project/config5g/proto/client"
-	protos "github.com/omec-project/config5g/proto/sdcoreConfig"
+	grpcClient "github.com/5GC-DEV/config5g-cdac/proto/client"
+	protos "github.com/5GC-DEV/config5g-cdac/proto/sdcoreConfig"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/udr/consumer"
 	"github.com/omec-project/udr/context"


### PR DESCRIPTION
📌 Description:
This PR introduces support for associating multiple DNNs to a single device group in the 5G Core, enabling flexible and scalable configurations in deployments with a single UPF.

✅ Key Highlights:
Introduced configuration support for multiple DNNs per IMSI range in the sdcore-5g-values.yml file.

Each DNN can have its own:

IP pool

MTU

DNS

UE QoS profile (including MBR uplink/downlink and traffic class)

Validated end-to-end traffic flow for both ims and internet DNNs over the same UPF.

📂 Configuration Changes (in sdcore-5g-values.yml):

✅ device-groups Section:

ip-domains list now includes multiple DNNs (ims, internet) under a single group (gnbsim-user-group1).
ip-domain-expanded changed to ip-domains
Each DNN is mapped to a different ue-ip-pool and ue-dnn-qos.
 device-groups:
            - name:  "gnbsim-user-group1"
              imsis:
                - "208930100007487"
                - "208930100007488"
                - "208930100007489"
                - "208930100007490"
                - "208930100007491"
                - "208930100007492"
                - "208930100007493"
                - "208930100007494"
                - "208930100007495"
                - "208930100007496"                         
              ip-domain-name: "pool1"
              ip-domains:
                - dnn: ims
                  dns-primary: "8.8.8.8"
                  mtu: 1400
                  ue-ip-pool: "172.252.0.0/16"
                  ue-dnn-qos:
                    dnn-mbr-downlink: 2400
                    dnn-mbr-uplink: 1200
                    bitrate-unit: Kbps
                    traffic-class:
                      name: "platinum"
                      qci: 5
                      arp: 1
                      pdb: 100
                      pelr: 6
                - dnn: internet
                  dns-primary: "10.176.0.11"
                  mtu: 1460
                  ue-ip-pool: {{ core.upf.default_upf.ue_ip_pool }}
                  ue-dnn-qos:
                    dnn-mbr-downlink: 1000
                    dnn-mbr-uplink: 1000
                    bitrate-unit: Mbps
                    traffic-class:
                      name: "platinum"
                      qci: 9
                      arp: 6
                      pdb: 300
                      pelr: 6            
              site-info: "enterprise"

✅ Userplane Section:
Defined dnn_list with individual DNNs and their respective ue_ip_pool.
cpiface:
  dnn_list:
    - dnn: "ims"
      ue_ip_pool: "172.252.0.0/16"
    - dnn: "internet"
      ue_ip_pool: "172.250.0.0/16"  # Must match slice DNN
  hostname: "upf"
  enable_ue_ip_alloc: false
