### PR TITLE
fix(udr): guard per-UE SDM subscription state against concurrent access

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -8,6 +8,7 @@ package context
 import (
 	"fmt"
 	"sync"
+	"sync/atomic"
 
 	"github.com/omec-project/openapi/v2/models"
 )
@@ -25,7 +26,6 @@ const (
 func init() {
 	UDR_Self().Name = "udr"
 	UDR_Self().EeSubscriptionIDGenerator = 1
-	UDR_Self().SdmSubscriptionIDGenerator = 1
 	UDR_Self().SubscriptionDataSubscriptionIDGenerator = 1
 	UDR_Self().PolicyDataSubscriptionIDGenerator = 1
 	UDR_Self().SubscriptionDataSubscriptions = make(map[subsId]*models.SubscriptionDataSubscriptions)
@@ -49,15 +49,30 @@ type UDRContext struct {
 	mtx                                     sync.RWMutex
 	SBIPort                                 int
 	EeSubscriptionIDGenerator               int
-	SdmSubscriptionIDGenerator              int
+	SdmSubscriptionIDGenerator              atomic.Int64
 	PolicyDataSubscriptionIDGenerator       int
 	SubscriptionDataSubscriptionIDGenerator int
 	appDataInfluDataSubscriptionIdGenerator uint64
 }
 
+// UESubsData holds the per-UE subscription maps.
+//
+// Mtx guards SdmSubscriptions. The UDM creates an SDM subscription per
+// registration, one goroutine per in-flight registration, so unsynchronised
+// access there aborts the process with "concurrent map writes".
+//
+// EeSubscriptionCollection is deliberately left alone. Its ~20 call sites read
+// and write it without taking Mtx, and CreateEeSubscriptionsProcedure still
+// installs the per-UE entry with Load followed by Store, so two hazards remain
+// on that path: concurrent map writes, and an entry replacement that discards
+// SDM subscriptions already recorded. Both predate this change and want the
+// same treatment applied here, but across every EE site rather than piecemeal --
+// guarding only some of them, or making concurrent EE creators share one
+// instance without guarding the map, converts a lost update into a crash.
 type UESubsData struct {
 	EeSubscriptionCollection map[subsId]*EeSubscriptionCollection
 	SdmSubscriptions         map[subsId]*models.SdmSubscription
+	Mtx                      sync.RWMutex
 }
 
 type UEGroupSubsData struct {

--- a/producer/data_repository.go
+++ b/producer/data_repository.go
@@ -2812,9 +2812,10 @@ func RemovesdmSubscriptionsProcedure(ueId string, subsId string) *models.Problem
 	}
 
 	UESubsData := value.(*udr_context.UESubsData)
-	_, ok = UESubsData.SdmSubscriptions[subsId]
+	UESubsData.Mtx.Lock()
+	defer UESubsData.Mtx.Unlock()
 
-	if !ok {
+	if _, ok = UESubsData.SdmSubscriptions[subsId]; !ok {
 		return utils.ProblemDetailsWithCause("Subscription not found", http.StatusNotFound, "", utils.CauseSubscriptionNotFound)
 	}
 	delete(UESubsData.SdmSubscriptions, subsId)
@@ -2849,9 +2850,10 @@ func UpdatesdmsubscriptionsProcedure(ueId string, subsId string,
 	}
 
 	UESubsData := value.(*udr_context.UESubsData)
-	_, ok = UESubsData.SdmSubscriptions[subsId]
+	UESubsData.Mtx.Lock()
+	defer UESubsData.Mtx.Unlock()
 
-	if !ok {
+	if _, ok = UESubsData.SdmSubscriptions[subsId]; !ok {
 		return utils.ProblemDetailsWithCause("Subscription not found", http.StatusNotFound, "", utils.CauseSubscriptionNotFound)
 	}
 	SdmSubscription.SetSubscriptionId(subsId)
@@ -2880,20 +2882,22 @@ func CreateSdmSubscriptionsProcedure(SdmSubscription models.SdmSubscription,
 ) (string, models.SdmSubscription) {
 	udrSelf := udr_context.UDR_Self()
 
-	value, ok := udrSelf.UESubsCollection.Load(ueId)
-	if !ok {
-		udrSelf.UESubsCollection.Store(ueId, new(udr_context.UESubsData))
-		value, _ = udrSelf.UESubsCollection.Load(ueId)
-	}
+	// LoadOrStore keeps concurrent creators for the same ueId on one instance;
+	// a Load/Store pair would let two goroutines install competing values.
+	value, _ := udrSelf.UESubsCollection.LoadOrStore(ueId, new(udr_context.UESubsData))
 	UESubsData := value.(*udr_context.UESubsData)
+
+	// Allocated before taking the lock: the generator is shared across every
+	// UE, so it must not be serialised behind a per-UE lock.
+	newSubscriptionID := strconv.FormatInt(udrSelf.SdmSubscriptionIDGenerator.Add(1), 10)
+	SdmSubscription.SetSubscriptionId(newSubscriptionID)
+
+	UESubsData.Mtx.Lock()
+	defer UESubsData.Mtx.Unlock()
 	if UESubsData.SdmSubscriptions == nil {
 		UESubsData.SdmSubscriptions = make(map[string]*models.SdmSubscription)
 	}
-
-	newSubscriptionID := strconv.Itoa(udrSelf.SdmSubscriptionIDGenerator)
-	SdmSubscription.SetSubscriptionId(newSubscriptionID)
 	UESubsData.SdmSubscriptions[newSubscriptionID] = &SdmSubscription
-	udrSelf.SdmSubscriptionIDGenerator++
 
 	/* Contains the URI of the newly created resource, according
 	   to the structure: {apiRoot}/subscription-data/{ueId}/context-data/sdm-subscriptions/{subsId}' */
@@ -2934,9 +2938,11 @@ func QuerysdmsubscriptionsProcedure(ueId string) (*[]models.SdmSubscription, *mo
 	UESubsData := value.(*udr_context.UESubsData)
 	var sdmSubscriptionSlice []models.SdmSubscription
 
+	UESubsData.Mtx.RLock()
 	for _, v := range UESubsData.SdmSubscriptions {
 		sdmSubscriptionSlice = append(sdmSubscriptionSlice, *v)
 	}
+	UESubsData.Mtx.RUnlock()
 	return &sdmSubscriptionSlice, nil
 }
 

--- a/producer/data_repository_test.go
+++ b/producer/data_repository_test.go
@@ -4,9 +4,12 @@
 package producer
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/omec-project/openapi/v2/models"
+	udr_context "github.com/omec-project/udr/context"
 	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
@@ -160,5 +163,71 @@ func TestAddDotSafeKeyExistsFilterMergesExistingExpr(t *testing.T) {
 	}
 	if _, hasIn := newExpr["$in"]; !hasIn {
 		t.Fatal("expected $in operator in merged $expr")
+	}
+}
+
+// TestCreateSdmSubscriptionsProcedureIsConcurrencySafe reproduces the crash
+// seen on a live core once registration concurrency rose: the UDM creates an
+// SDM subscription per registration, and unsynchronised access to
+// UESubsData.SdmSubscriptions aborted the process with "concurrent map
+// writes". Run with -race to also catch the shared ID generator.
+func TestCreateSdmSubscriptionsProcedureIsConcurrencySafe(t *testing.T) {
+	const (
+		ueCount       = 8
+		perUeRequests = 64
+	)
+
+	// UESubsCollection is a process-wide singleton, so leaving these entries
+	// behind would make a second run in the same process (go test -count=2, or
+	// any later test reusing these IDs) see the accumulated subscriptions and
+	// fail the count assertion.
+	udrSelf := udr_context.UDR_Self()
+	ueIds := make([]string, 0, ueCount)
+	for u := 0; u < ueCount; u++ {
+		ueIds = append(ueIds, fmt.Sprintf("imsi-20893010000%04d", u))
+	}
+	clearUeSubs := func() {
+		for _, id := range ueIds {
+			udrSelf.UESubsCollection.Delete(id)
+		}
+	}
+	clearUeSubs()
+	t.Cleanup(clearUeSubs)
+
+	var wg sync.WaitGroup
+	for u := 0; u < ueCount; u++ {
+		ueId := fmt.Sprintf("imsi-20893010000%04d", u)
+		for r := 0; r < perUeRequests; r++ {
+			wg.Add(1)
+			go func(ueId string) {
+				defer wg.Done()
+				CreateSdmSubscriptionsProcedure(models.SdmSubscription{}, "subscriptionData.contextData.sdmSubscriptions", ueId)
+			}(ueId)
+		}
+	}
+	wg.Wait()
+
+	// Every request must be recorded, and each subscription must have a
+	// distinct ID: a racing generator would hand out duplicates and lose rows.
+	seen := make(map[string]string)
+	for u := 0; u < ueCount; u++ {
+		ueId := fmt.Sprintf("imsi-20893010000%04d", u)
+		value, ok := udrSelf.UESubsCollection.Load(ueId)
+		if !ok {
+			t.Fatalf("no UESubsData stored for %s", ueId)
+		}
+		subs := value.(*udr_context.UESubsData)
+		subs.Mtx.RLock()
+		got := len(subs.SdmSubscriptions)
+		for id := range subs.SdmSubscriptions {
+			if prev, dup := seen[id]; dup {
+				t.Errorf("subscription ID %s reused by %s and %s", id, prev, ueId)
+			}
+			seen[id] = ueId
+		}
+		subs.Mtx.RUnlock()
+		if got != perUeRequests {
+			t.Errorf("%s: got %d subscriptions, want %d", ueId, got, perUeRequests)
+		}
 	}
 }


### PR DESCRIPTION
`CreateSdmSubscriptionsProcedure` writes `UESubsData.SdmSubscriptions` — a plain map — with no synchronisation. The UDM creates one SDM subscription per registration, i.e. one goroutine per in-flight attach, so concurrent registrations abort the UDR process:

```
fatal error: concurrent map writes
```

Exit 134, taking subscriber data access down with it.

Three races on the same state:

1. Unsynchronised map writes on `SdmSubscriptions`, plus a check-then-act initialisation of the map itself.
2. `SdmSubscriptionIDGenerator++` — a read-modify-write that also hands out duplicate subscription IDs under concurrency, a correctness bug independent of the crash.
3. A Load/Store gap on the per-UE entry, where two goroutines each construct a `UESubsData` and one silently wins.

Fix: a mutex on `UESubsData` guarding the access sites, `atomic.Int32` for the generator, and `LoadOrStore` for the per-UE entry.

Why it has gone unseen: registration throughput in a stock deployment is low enough that colliding writes are rare (an unrelated NRF-cache defect serializes attaches — see omec-project/openapi#170). Once registration concurrency rises the crash reproduces consistently; with this fix the same deployment survives sustained 2000-UE registration runs that previously killed the UDR.

Regression test added; it fails under `-race` without the fix. `go build ./...` and `go test -race ./producer/` pass.